### PR TITLE
Retain big TextPool memory softly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/io/trino/tpch/CustomerGenerator.java
+++ b/src/main/java/io/trino/tpch/CustomerGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
@@ -37,14 +38,14 @@ public class CustomerGenerator
     private final int partCount;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public CustomerGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public CustomerGenerator(double scaleFactor, int part, int partCount, Distributions distributions, TextPool textPool)
+    public CustomerGenerator(double scaleFactor, int part, int partCount, Distributions distributions, Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -63,7 +64,7 @@ public class CustomerGenerator
     {
         return new CustomerGeneratorIterator(
                 distributions,
-                textPool,
+                textPool.get(),
                 calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
     }

--- a/src/main/java/io/trino/tpch/LineItemGenerator.java
+++ b/src/main/java/io/trino/tpch/LineItemGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
@@ -55,14 +56,14 @@ public class LineItemGenerator
     private final int partCount;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public LineItemGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public LineItemGenerator(double scaleFactor, int part, int partCount, Distributions distributions, TextPool textPool)
+    public LineItemGenerator(double scaleFactor, int part, int partCount, Distributions distributions, Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -81,7 +82,7 @@ public class LineItemGenerator
     {
         return new LineItemGeneratorIterator(
                 distributions,
-                textPool,
+                textPool.get(),
                 scaleFactor,
                 calculateStartIndex(OrderGenerator.SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(OrderGenerator.SCALE_BASE, scaleFactor, part, partCount));

--- a/src/main/java/io/trino/tpch/NationGenerator.java
+++ b/src/main/java/io/trino/tpch/NationGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,14 +26,14 @@ public class NationGenerator
     private static final int COMMENT_AVERAGE_LENGTH = 72;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public NationGenerator()
     {
         this(Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public NationGenerator(Distributions distributions, TextPool textPool)
+    public NationGenerator(Distributions distributions, Supplier<TextPool> textPool)
     {
         this.distributions = requireNonNull(distributions, "distributions is null");
         this.textPool = requireNonNull(textPool, "textPool is null");
@@ -41,7 +42,7 @@ public class NationGenerator
     @Override
     public Iterator<Nation> iterator()
     {
-        return new NationGeneratorIterator(distributions.getNations(), textPool);
+        return new NationGeneratorIterator(distributions.getNations(), textPool.get());
     }
 
     private static class NationGeneratorIterator

--- a/src/main/java/io/trino/tpch/OrderGenerator.java
+++ b/src/main/java/io/trino/tpch/OrderGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.padStart;
@@ -58,14 +59,14 @@ public class OrderGenerator
     private final int partCount;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public OrderGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public OrderGenerator(double scaleFactor, int part, int partCount, Distributions distributions, TextPool textPool)
+    public OrderGenerator(double scaleFactor, int part, int partCount, Distributions distributions, Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -84,7 +85,7 @@ public class OrderGenerator
     {
         return new OrderGeneratorIterator(
                 distributions,
-                textPool,
+                textPool.get(),
                 scaleFactor,
                 calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));

--- a/src/main/java/io/trino/tpch/PartGenerator.java
+++ b/src/main/java/io/trino/tpch/PartGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
@@ -41,14 +42,14 @@ public class PartGenerator
     private final int partCount;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public PartGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public PartGenerator(double scaleFactor, int part, int partCount, Distributions distributions, TextPool textPool)
+    public PartGenerator(double scaleFactor, int part, int partCount, Distributions distributions, Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -67,7 +68,7 @@ public class PartGenerator
     {
         return new PartGeneratorIterator(
                 distributions,
-                textPool,
+                textPool.get(),
                 calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
     }

--- a/src/main/java/io/trino/tpch/PartSupplierGenerator.java
+++ b/src/main/java/io/trino/tpch/PartSupplierGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
@@ -39,14 +40,14 @@ public class PartSupplierGenerator
     private final int part;
     private final int partCount;
 
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public PartSupplierGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, TextPool.getDefaultTextPool());
     }
 
-    public PartSupplierGenerator(double scaleFactor, int part, int partCount, TextPool textPool)
+    public PartSupplierGenerator(double scaleFactor, int part, int partCount, Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -63,7 +64,7 @@ public class PartSupplierGenerator
     public Iterator<PartSupplier> iterator()
     {
         return new PartSupplierGeneratorIterator(
-                textPool,
+                textPool.get(),
                 scaleFactor,
                 calculateStartIndex(PartGenerator.SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(PartGenerator.SCALE_BASE, scaleFactor, part, partCount));

--- a/src/main/java/io/trino/tpch/RegionGenerator.java
+++ b/src/main/java/io/trino/tpch/RegionGenerator.java
@@ -16,6 +16,7 @@ package io.trino.tpch;
 import com.google.common.collect.AbstractIterator;
 
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,14 +26,14 @@ public class RegionGenerator
     private static final int COMMENT_AVERAGE_LENGTH = 72;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final Supplier<TextPool> textPool;
 
     public RegionGenerator()
     {
         this(Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public RegionGenerator(Distributions distributions, TextPool textPool)
+    public RegionGenerator(Distributions distributions, Supplier<TextPool> textPool)
     {
         this.distributions = requireNonNull(distributions, "distributions is null");
         this.textPool = requireNonNull(textPool, "textPool is null");
@@ -41,7 +42,7 @@ public class RegionGenerator
     @Override
     public Iterator<Region> iterator()
     {
-        return new RegionGeneratorIterator(distributions.getRegions(), textPool);
+        return new RegionGeneratorIterator(distributions.getRegions(), textPool.get());
     }
 
     private static class RegionGeneratorIterator

--- a/src/main/java/io/trino/tpch/SharingTextPoolSupplier.java
+++ b/src/main/java/io/trino/tpch/SharingTextPoolSupplier.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tpch;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.lang.ref.SoftReference;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+final class SharingTextPoolSupplier
+        implements Supplier<TextPool>
+{
+    private static final Logger log = Logger.getLogger(SharingTextPoolSupplier.class.getName());
+
+    private final ScheduledExecutorService executor;
+    private final Supplier<TextPool> loader;
+
+    @GuardedBy("this")
+    private SoftReference<TextPool> shared = new SoftReference<>(null);
+
+    public SharingTextPoolSupplier(ScheduledExecutorService executor, Supplier<TextPool> loader)
+    {
+        this.executor = requireNonNull(executor, "executor is null");
+        this.loader = requireNonNull(loader, "loader is null");
+    }
+
+    // Synchronize to ensure there is only one TextPool retained at given point in time.
+    @Override
+    public synchronized TextPool get()
+    {
+        TextPool textPool = shared.get();
+        if (textPool == null) {
+            TextPool newTextPool = loader.get();
+            log.fine(() -> format("Loaded TextPool %s", Integer.toHexString(System.identityHashCode(newTextPool))));
+            shared = new SoftReference<>(newTextPool);
+            executor.schedule(
+                    () -> {
+                        log.fine(() -> format("Releasing strong reference to TextPool %s", Integer.toHexString(System.identityHashCode(newTextPool))));
+                    },
+                    // Creating new TextPool takes under a second on a modern laptop.
+                    10,
+                    SECONDS);
+            textPool = newTextPool;
+        }
+        return textPool;
+    }
+}

--- a/src/main/java/io/trino/tpch/SupplierGenerator.java
+++ b/src/main/java/io/trino/tpch/SupplierGenerator.java
@@ -45,14 +45,14 @@ public class SupplierGenerator
     private final int partCount;
 
     private final Distributions distributions;
-    private final TextPool textPool;
+    private final java.util.function.Supplier<TextPool> textPool;
 
     public SupplierGenerator(double scaleFactor, int part, int partCount)
     {
         this(scaleFactor, part, partCount, Distributions.getDefaultDistributions(), TextPool.getDefaultTextPool());
     }
 
-    public SupplierGenerator(double scaleFactor, int part, int partCount, Distributions distributions, TextPool textPool)
+    public SupplierGenerator(double scaleFactor, int part, int partCount, Distributions distributions, java.util.function.Supplier<TextPool> textPool)
     {
         checkArgument(scaleFactor > 0, "scaleFactor must be greater than 0");
         checkArgument(part >= 1, "part must be at least 1");
@@ -71,7 +71,7 @@ public class SupplierGenerator
     {
         return new SupplierGeneratorIterator(
                 distributions,
-                textPool,
+                textPool.get(),
                 calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
                 calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
     }


### PR DESCRIPTION
Before the change, the TextPool.DEFAULT_TEXT_POOL would be a strongly
referenced, 300 MB memory block. After the change, it's loaded when
used, and shared opportunistically, by keeping it on a soft reference.
Additionally, a strong reference is kept for 10 seconds to avoid
trashing. On author's laptop, new TextPool gets created in approximately
0.85 s.

This is expected to reduce memory usage for applications that generate
TPC-H data from time to time.