### PR TITLE
Improve performance of data generation

### DIFF
--- a/src/main/java/io/trino/tpch/Customer.java
+++ b/src/main/java/io/trino/tpch/Customer.java
@@ -14,7 +14,7 @@
 package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Customer
@@ -97,15 +97,6 @@ public class Customer
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%s|%s|%d|%s|%s|%s|%s|",
-                customerKey,
-                name,
-                address,
-                nationKey,
-                phone,
-                formatMoney(accountBalance),
-                marketSegment,
-                comment);
+        return buildLine(customerKey, name, address, nationKey, phone, formatMoney(accountBalance), marketSegment, comment);
     }
 }

--- a/src/main/java/io/trino/tpch/LineItem.java
+++ b/src/main/java/io/trino/tpch/LineItem.java
@@ -15,7 +15,7 @@ package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatDate;
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class LineItem
@@ -180,8 +180,7 @@ public class LineItem
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%d|%d|%d|%d|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|",
+        return buildLine(
                 orderKey,
                 partKey,
                 supplierKey,

--- a/src/main/java/io/trino/tpch/Nation.java
+++ b/src/main/java/io/trino/tpch/Nation.java
@@ -13,7 +13,7 @@
  */
 package io.trino.tpch;
 
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Nation
@@ -63,6 +63,6 @@ public class Nation
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH, "%d|%s|%d|%s|", nationKey, name, regionKey, comment);
+        return buildLine(nationKey, name, regionKey, comment);
     }
 }

--- a/src/main/java/io/trino/tpch/Order.java
+++ b/src/main/java/io/trino/tpch/Order.java
@@ -15,7 +15,7 @@ package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatDate;
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Order
@@ -114,8 +114,7 @@ public class Order
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%d|%s|%s|%s|%s|%s|%d|%s|",
+        return buildLine(
                 orderKey,
                 customerKey,
                 orderStatus,

--- a/src/main/java/io/trino/tpch/OrderGenerator.java
+++ b/src/main/java/io/trino/tpch/OrderGenerator.java
@@ -18,6 +18,7 @@ import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.padStart;
 import static io.trino.tpch.GenerateUtils.MIN_GENERATE_DATE;
 import static io.trino.tpch.GenerateUtils.TOTAL_DATE_RANGE;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
@@ -30,7 +31,6 @@ import static io.trino.tpch.LineItemGenerator.createQuantityRandom;
 import static io.trino.tpch.LineItemGenerator.createShipDateRandom;
 import static io.trino.tpch.LineItemGenerator.createTaxRandom;
 import static io.trino.tpch.PartGenerator.calculatePartPrice;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class OrderGenerator
@@ -226,7 +226,7 @@ public class OrderGenerator
                     totalPrice,
                     toEpochDate(orderDate),
                     orderPriorityRandom.nextValue(),
-                    String.format(ENGLISH, "Clerk#%09d", clerkRandom.nextValue()),
+                    "Clerk#" + padStart(Integer.toString(clerkRandom.nextValue()), 9, '0'),
                     0,
                     commentRandom.nextValue());
         }

--- a/src/main/java/io/trino/tpch/Part.java
+++ b/src/main/java/io/trino/tpch/Part.java
@@ -14,7 +14,7 @@
 package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Part
@@ -113,9 +113,7 @@ public class Part
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%s|%s|%s|%s|%d|%s|%s|%s|",
-                partKey,
+        return buildLine(partKey,
                 name,
                 manufacturer,
                 brand,

--- a/src/main/java/io/trino/tpch/PartGenerator.java
+++ b/src/main/java/io/trino/tpch/PartGenerator.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
 import static io.trino.tpch.GenerateUtils.calculateStartIndex;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class PartGenerator
@@ -143,8 +142,8 @@ public class PartGenerator
             return new Part(partKey,
                     partKey,
                     name,
-                    String.format(ENGLISH, "Manufacturer#%d", manufacturer),
-                    String.format(ENGLISH, "Brand#%d", brand),
+                    "Manufacturer#" + manufacturer,
+                    "Brand#" + brand,
                     typeRandom.nextValue(),
                     sizeRandom.nextValue(),
                     containerRandom.nextValue(),

--- a/src/main/java/io/trino/tpch/PartSupplier.java
+++ b/src/main/java/io/trino/tpch/PartSupplier.java
@@ -14,7 +14,7 @@
 package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class PartSupplier
@@ -76,12 +76,6 @@ public class PartSupplier
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%d|%d|%s|%s|",
-                partKey,
-                supplierKey,
-                availableQuantity,
-                formatMoney(supplyCost),
-                comment);
+        return buildLine(partKey, supplierKey, availableQuantity, formatMoney(supplyCost), comment);
     }
 }

--- a/src/main/java/io/trino/tpch/RandomPhoneNumber.java
+++ b/src/main/java/io/trino/tpch/RandomPhoneNumber.java
@@ -13,7 +13,7 @@
  */
 package io.trino.tpch;
 
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.padWithZeros;
 
 public class RandomPhoneNumber
         extends AbstractRandomInt
@@ -33,11 +33,9 @@ public class RandomPhoneNumber
 
     public String nextValue(long nationKey)
     {
-        return String.format(ENGLISH,
-                "%02d-%03d-%03d-%04d",
-                (10 + (nationKey % NATIONS_MAX)),
-                nextInt(100, 999),
-                nextInt(100, 999),
-                nextInt(1000, 9999));
+        return padWithZeros(10 + (nationKey % NATIONS_MAX), 2) + '-' +
+                padWithZeros(nextInt(100, 999), 3) + '-' +
+                padWithZeros(nextInt(100, 999), 3) + '-' +
+                padWithZeros(nextInt(1000, 9999), 4);
     }
 }

--- a/src/main/java/io/trino/tpch/Region.java
+++ b/src/main/java/io/trino/tpch/Region.java
@@ -13,7 +13,7 @@
  */
 package io.trino.tpch;
 
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Region
@@ -56,6 +56,6 @@ public class Region
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH, "%d|%s|%s|", regionKey, name, comment);
+        return buildLine(regionKey, name, comment);
     }
 }

--- a/src/main/java/io/trino/tpch/StringUtils.java
+++ b/src/main/java/io/trino/tpch/StringUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tpch;
+
+import com.google.common.base.Joiner;
+
+import static com.google.common.base.Strings.padStart;
+
+public class StringUtils
+{
+    private static final Joiner LINE_JOINER = Joiner.on('|');
+
+    private StringUtils() {}
+
+    public static String padWithZeros(long value, int length)
+    {
+        return padStart(Long.toString(value), length, '0');
+    }
+
+    public static String buildLine(Object... values)
+    {
+        return LINE_JOINER.join(values) + "|";
+    }
+}

--- a/src/main/java/io/trino/tpch/Supplier.java
+++ b/src/main/java/io/trino/tpch/Supplier.java
@@ -14,7 +14,7 @@
 package io.trino.tpch;
 
 import static io.trino.tpch.GenerateUtils.formatMoney;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.buildLine;
 import static java.util.Objects.requireNonNull;
 
 public class Supplier
@@ -90,8 +90,7 @@ public class Supplier
     @Override
     public String toLine()
     {
-        return String.format(ENGLISH,
-                "%d|%s|%s|%d|%s|%s|%s|",
+        return buildLine(
                 supplierKey,
                 name,
                 address,

--- a/src/main/java/io/trino/tpch/SupplierGenerator.java
+++ b/src/main/java/io/trino/tpch/SupplierGenerator.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.tpch.GenerateUtils.calculateRowCount;
 import static io.trino.tpch.GenerateUtils.calculateStartIndex;
-import static java.util.Locale.ENGLISH;
+import static io.trino.tpch.StringUtils.padWithZeros;
 import static java.util.Objects.requireNonNull;
 
 public class SupplierGenerator
@@ -175,7 +175,7 @@ public class SupplierGenerator
 
             return new Supplier(supplierKey,
                     supplierKey,
-                    String.format(ENGLISH, "Supplier#%09d", supplierKey),
+                    "Supplier#" + padWithZeros(supplierKey, 9),
                     addressRandom.nextValue(),
                     nationKey,
                     phoneRandom.nextValue(nationKey),


### PR DESCRIPTION
For even a simple query performance is much much better:

After:
```
trino> select lower(orderstatus), count(1) from tpch.sf100.orders group by lower(orderstatus);
 _col0 |  _col1
-------+----------
 p     |  3841445
 o     | 73086053
 f     | 73072502
(3 rows)

Query 20230413_162027_00025_v32u9, FINISHED, 3 nodes
Splits: 54 total, 54 done (100.00%)
9.38 [150M rows, 0B] [16M rows/s, 0B/s]
```

Before:
```
trino> select lower(orderstatus), count(1) from tpch.sf100.orders group by lower(orderstatus);
 _col0 |  _col1
-------+----------
 p     |  3841445
 o     | 73086053
 f     | 73072502
(3 rows)

Query 20230413_171901_00025_x7epn, FINISHED, 3 nodes
Splits: 54 total, 54 done (100.00%)
15.32 [150M rows, 0B] [9.79M rows/s, 0B/s]
```